### PR TITLE
修复搜索商品问题

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -239,74 +239,7 @@ function fetchBidDetail(auctionDetailCurl) {
 	});
 }
 
-/**
- * 搜索产品请求
- * status: ""：全部，1：即将开始，2：正在进行
- * */
-function fetchProduct(params = {}) {
-	const { name, pageNo = 1, status = "" } = params;
-	return new Promise((resolve, reject) => {
 
-		let path, params;
-		if (name) {
-			path = `${API.api_jd_path}?functionId=pp.dbd.biz.search.query&t=${new Date().getTime()}&appid=paipai_h5`;
-			params = { pageNo: pageNo, pageSize: 20, key: name, status: status, sort: "endTime_asc", specialType: 1, mpSource: 1, sourceTag: 2 };
-		} else {
-			path = `${API.api_jd_path}?functionId=dbd.auction.list.v2&t=${new Date().getTime()}&appid=paipai_h5`;
-			params = { pageNo: pageNo, pageSize: 20, key: name, status: status, auctionFilterTime: 180, isPersonalRecommend: 0, p: 2, skuGroup: 1, mpSource: 1, sourceTag: 2 };
-		}
-
-		const options = {
-			hostname: API.api_jd_hostname,
-			port: 443,
-			path: path,
-			method: "POST",
-			headers: {
-				"Content-Type": 'application/x-www-form-urlencoded',
-				"User-Agent": "jdapp;android;12.0.2;;;M/5.0;appBuild/98787;ef/1;ep/%7B%22hdid%22%3A%22JM9F1ywUPwflvMIpYPok0tt5k9kW4ArJEU3lfLhxBqw%3D%22%2C%22ts%22%3A1685444654944%2C%22ridx%22%3A-1%2C%22cipher%22%3A%7B%22sv%22%3A%22CJC%3D%22%2C%22ad%22%3A%22CtG3YtCyDtc3EJCmC2OyYm%3D%3D%22%2C%22od%22%3A%22CzY5ZJU0CQU3C2OyEJvwYq%3D%3D%22%2C%22ov%22%3A%22CzC%3D%22%2C%22ud%22%3A%22CtG3YtCyDtc3EJCmC2OyYm%3D%3D%22%7D%2C%22ciphertype%22%3A5%2C%22version%22%3A%221.2.0%22%2C%22appname%22%3A%22com.jingdong.app.mall%22%7D;jdSupportDarkMode/0;Mozilla/5.0 (Linux; Android 13; MI 8 Build/TKQ1.220905.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/89.0.4389.72 MQQBrowser/6.2 TBS/046247 Mobile Safari/537.36",
-				"Referer": API.app_api_header_referer,
-				"Sec-Fetch-Mode": "cors"
-			}
-		};
-
-		const bodyParams = {};
-		bodyParams.body = JSON.stringify(params);
-		const postData = querystring.stringify(bodyParams);
-
-		const req = https.request(options, (res) => {
-			let rawData = "";
-
-			res.setEncoding('utf8');
-
-			res.on('data', (chunk) => {
-				rawData += chunk;
-			});
-
-			res.on('end', () => {
-				let data = null;
-				try {
-					if (rawData) {
-						const parsedData = JSON.parse(rawData);
-						if (parsedData.result && parsedData.result.data) {
-							data = parsedData.result.data;
-						}
-					}
-				} catch (e) {
-					consoleUtil.error("fetchProduct error:", e.message);
-				}
-				resolve(data);
-			});
-		});
-
-		req.on('error', (e) => {
-			consoleUtil.error(`fetchProduct 请求遇到问题: ${e.message}`);
-			reject(e);
-		});
-
-		req.write(postData);
-		req.end();
-	});
-}
 
 /**
  * 避免服务端限流的循环请求
@@ -344,7 +277,6 @@ module.exports = {
 	postOfferPrice,
 	fetchBatchInfo,
 	fetchBidDetail,
-	fetchProduct,
 	loopRequestAvoidCurrentLimiting,
 	sleep,
 	checkAuctionDetailCurl

--- a/src/components/ProductList.vue
+++ b/src/components/ProductList.vue
@@ -74,9 +74,11 @@
       <el-table-column prop="currentPrice" label="当前价"></el-table-column>
       <!-- <el-table-column prop="spectatorCount" label="围观数"> </el-table-column> -->
     </el-table>
+    <!-- 没什么用了
     <el-pagination layout="prev, pager, next, jumper" :page-count="productSearchResult.pageCount" :page-size="20"
       :current-page="productSearchResult.pageNo" @current-change="fetchProduct" :total="productSearchResult.count"
       class="pagination-class" />
+  -->
   </div>
 </template>
 
@@ -146,23 +148,7 @@ export default defineComponent({
             })
             .then((data) => {
               if (data) {
-                // 有无商品调用接口不同，返回数据格式也不同
-                if (searchName) {
-                  if (data.itemList && data.itemList.length > 0) {
-                    // 根据开始时间重新排序
-                    data.itemList.sort((a, b) => {
-                      return a.startTime - b.startTime;
-                    });
-                  }
-                  dataMap.productSearchResult = data;
-                } else {
-                  dataMap.productSearchResult = {
-                    pageCount: Math.ceil(data.totalNumber / 20),
-                    count: data.totalNumber,
-                    pageNo: pageNo,
-                    itemList: data.auctionInfos,
-                  };
-                }
+                dataMap.productSearchResult = data;
               } else {
                 dataMap.productSearchResult = { pageCount: 0 };
               }


### PR DESCRIPTION
原有搜索商品的接口返回403，应该是被反爬了。
我这边尝试另外的途径实现了一下，思路如下，抛砖引玉。
1. 访问https://paipai.jd.com/auction-list/并捕获商品列表请求
2. 翻页，缓存最近一小时的所有数据。（可编辑代码缓存更久，但注意添加随机sleep，防止限流）
3. 搜索时直接从已缓存的数据中过滤即可

实现得比较简陋，只做个参考，大佬可以指导一下接下来的优化思路？